### PR TITLE
Updated Dockerfile for latest OpenROAD 12.0 patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,11 @@ Before running the script
 
 - Git clone will extract the files and place them in a directory (e.g. `openroad_server_docker`) which will be the base directory for the setup. `git clone https://alm.actian.com/bitbucket/scm/or/openroad_server_docker.git`
 - Check `saveset` directory for known working versions
-- Download the latest version of RPM based ActianX 12.0 for Linux 64-bit and place it in the `saveset` directory (e.g. `openroad_server_docker`). See `INGRES_ARCHIVE` in Dockerfile.
+- Download the latest version of Non-RPM based ActianX 12.0 for Linux 64-bit and place it in the `saveset` directory (e.g. `openroad_server_docker`). See `INGRES_ARCHIVE` in Dockerfile.
 - Download the latest version of OpenROAD 12.0 for Linux 64-bit and place it in the `saveset` directory (e.g. `openroad_server_docker`). See `OPENROAD_ARCHIVE` in Dockerfile.
-- Download the tar.gz Apache Tomcat package from the Apache Tomcat page and place it in the `saveset` directory (e.g. `openroad_server_docker`). See `TOMCAT_ARCHIVE` in Dockerfile.
-- Get OpenROAD `licence.xml` from https://actian.atlassian.net/wiki/spaces/GlobalSupport/pages/12486370/Emergency+Licenses and place it inside licdata directory in the base directory (eg. `openroad_server_docker/licdata`)
-- If you want to deploy new OpenROAD Server application then copy orjarinstall_cfg.json, orjarinstall.py and orserver-add-<appname>.zip in the `saveset` directory.
-- Keep mandatory orjarinstall_cfg.json file in `saveset` directory. This file will be copied to $II_SYTEM/ingres/files
-- The JSON file orjarinstall_cfg.json should contain a JSON object {...} with the following members (all optional):
-         "libu3gldir" - the directory shared libraries/DLLs are deployed into.
-             This directory should be contained in LD_LIBRARY_PATH (Linux) or PATH (Windows); default: $II_SYTEM/ingres/lib (Linux) or %II_SYSTEM%\ingres\bin (Windows)
-         "orjsonconfigdir" - the directory JSON config files for OpenROAD server applications are deployed into (default: $II_SYTEM/ingres/files/orjsonconfig)
-         "resourcedir" - the directory "resource*" directories (and their contents) are deployed into (default: $II_SYTEM/ingres)
-         "w4glappsdir" - the directory 4GL image files are deployed into; directory should be contained in II_W4GLAPPS_DIR (default: $II_SYTEM/ingres/w4glapps)
-- orserver-add-<appname>.zip is an archive containing the server application and other resources required
-  This archive can have the following subdirectories that will be processed:
-      - libu3gl - shared libraries/DLLs
-      - netutil - netutil command scripts
-      - orjsonconfig - JSON config files for OpenROAD server applications
-      - orserveradm_removeapp - JSON file to be used by the "orserveradm.py" script with RemoveApp command
-      - orserveradm_addapp - JSON file to be used by the "orserveradm.py" script with AddApp command
-      - resource* - Additional resource directories to be deployed
-      - w4glapps - OpenROAD Server application images
+- Download the latest version of tar.gz Apache Tomcat 9 package from the Apache Tomcat 9 page and place it in the `saveset` directory (e.g. `openroad_server_docker`). See `TOMCAT_ARCHIVE` in Dockerfile.
+- Place OpenROAD `licence.xml` inside licdata directory in the base directory (eg. `openroad_server_docker/licdata`)
+
 
 Once all the above steps are completed, run following commands 
 
@@ -51,6 +35,27 @@ The following directories are going to be used as volumes (`docker-compose.yml`)
 - `deploy/` - for configuration files, including tomcat, orserver.json and application json files.
 - `logs/` - catalina.out, w4gl.log and application logs
 
+## Deploy new OpenROAD Server application
+
+- If you want to deploy new OpenROAD Server application then copy orjarinstall.py and orserver-add-<appname>.zip in the `saveset` directory.
+- orjarinstall.py and sample orserver-add-l2pserver.zip is available under Assets https://github.com/ActianCorp/OpenROAD_docker/releases/tag/v0.0.1
+- orjarinstall_cfg.json file is available in `saveset` directory. This file will be copied to $II_SYTEM/ingres/files
+- The JSON file orjarinstall_cfg.json should contain a JSON object {...} with the following members (all optional):
+         "libu3gldir" - the directory shared libraries/DLLs are deployed into.
+             This directory should be contained in LD_LIBRARY_PATH (Linux) or PATH (Windows); default: $II_SYTEM/ingres/lib (Linux) or %II_SYSTEM%\ingres\bin (Windows)
+         "orjsonconfigdir" - the directory JSON config files for OpenROAD server applications are deployed into (default: $II_SYTEM/ingres/files/orjsonconfig)
+         "resourcedir" - the directory "resource*" directories (and their contents) are deployed into (default: $II_SYTEM/ingres)
+         "w4glappsdir" - the directory 4GL image files are deployed into; directory should be contained in II_W4GLAPPS_DIR (default: $II_SYTEM/ingres/w4glapps)
+- orserver-add-<appname>.zip is an archive containing the server application and other resources required
+  This archive can have the following subdirectories that will be processed:
+      - libu3gl - shared libraries/DLLs
+      - netutil - netutil command scripts
+      - orjsonconfig - JSON config files for OpenROAD server applications
+      - orserveradm_removeapp - JSON file to be used by the "orserveradm.py" script with RemoveApp command
+      - orserveradm_addapp - JSON file to be used by the "orserveradm.py" script with AddApp command
+      - resource* - Additional resource directories to be deployed
+      - w4glapps - OpenROAD Server application images
+
 
 ## Docker Cheat sheet items
 
@@ -66,7 +71,3 @@ Specific
     docker rm actian_orserver_demo
 
     docker image rm actian_orserver
-
-## Notes
-
-1. This is copy of https://alm.actian.com/bitbucket/scm/or/openroad_server_docker.git

--- a/ingOR.sh
+++ b/ingOR.sh
@@ -1,0 +1,16 @@
+# Actian X environment for OR installation
+
+TERM_INGRES=konsolel
+
+II_SYSTEM=/IngresOR
+export II_SYSTEM
+
+PATH=$II_SYSTEM/ingres/bin:$II_SYSTEM/ingres/utility:$PATH
+
+if [ ${LD_LIBRARY_PATH:-} ] ; then
+    LD_LIBRARY_PATH=$II_SYSTEM/ingres/lib:$II_SYSTEM/ingres/lib/lp32:$LD_LIBRARY_PATH
+else
+    LD_LIBRARY_PATH=/lib:/usr/lib:$II_SYSTEM/ingres/lib:$II_SYSTEM/ingres/lib/lp32
+fi
+
+export TERM_INGRES PATH LD_LIBRARY_PATH

--- a/ingbld_install.sh
+++ b/ingbld_install.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+cd $II_SYSTEM/ingres
+
+source $II_SYSTEM/ingres/.ingORsh
+
+II_HOSTNAME=localhost
+export II_HOSTNAME
+
+TARBALL=/tmp/actianx-*-x86_64*/ingres.tar
+
+tar -xvf $TARBALL install
+
+./install/ingbuild -acceptlicense -install=net,tm,esql -exresponse -file=$II_RESPONSE_FILE $TARBALL
+
+if [ $II_HOSTNAME ] ; then
+    ingsetenv II_HOSTNAME localhost
+fi

--- a/or_dockerctl.sh
+++ b/or_dockerctl.sh
@@ -87,7 +87,7 @@ echo "Starting Tomcat 9 ($CATALINA_HOME/bin/catalina.sh start)."
 su - $owner -c "$CATALINA_HOME/bin/catalina.sh start"
 
 echo "Starting the ORSPO Server."
-su - $owner -c "$II_SYSTEM/ingres/bin/orspogsvrstart.bash"
+su - $owner -c "$II_SYSTEM/ingres/bin/orspogsvrstart"
 echo "Started."
 
 while [ -f $runfile ]
@@ -102,6 +102,6 @@ runuser $owner -c "ingstop -mgmtsvr"
 echo "Tomcat stop"
 runuser $owner -c "$CATALINA_HOME/bin/catalina.sh stop"
 echo "orspogsvrstop"
-runuser $owner -c "$II_SYSTEM/ingres/bin/orspogsvrstop.bash"
+runuser $owner -c "$II_SYSTEM/ingres/bin/orspogsvrstop"
 echo "Done"
 

--- a/savesets/README.md
+++ b/savesets/README.md
@@ -2,22 +2,22 @@ Savesets go here.
 
 Known working ones:
 
-  * II 12.0.0 (a64.lnx/00)
-  * OR 12.0.0 (a64.lnx/00)
+  * II 12.0.0 (a64.lnx/00) GA Release
+  * OR 12.0.0 (a64.lnx/00) GA Release
 
 ## Checksums
 
     >> md5sum.exe *gz
-    7be86eb39608635c7e66760aaf31012b *actianx-12.0.0-100-com-linux-rpm-x86_64.tgz
-    978e3dca669d308414aed517e5014664 *apache-tomcat-9.0.88.tar.gz
-    b57e569bbcc9620491e79f34d66abb0e *or12_0_com.tar.gz
+    3e24f3add539c0746ab9ad2272a74dbe *actianx-12.0.0-100-com-linux-ingbuild-x86_64.tgz
+    33f0f4f585833c8885b79483695d2d1c *apache-tomcat-9.0.91.tar.gz
+    b2b15413a3b06bc741fdcc7beac146bd *openroad-12.00-15961-a64_lnx-com.tar.gz
 
 
 ## links
 
 ### or12_0_com.tar.gz
 
-  * https://esd.actian.com/product/Actian_OpenROAD/12.0/Linux_X86_64-bit/OpenROAD_12.0.0_Enterprise_Edition/or12_0_com.tar.gz/http
+  * https://esd.actian.com/product/Actian_OpenROAD/12.0/Linux_X86_64-bit/OpenROAD_12.0.0_Enterprise_Edition/openroad-12.00-15961-a64_lnx-com.tar.gz/http
 
 ### actianx-12.0.0-100-com-linux-rpm-x86_64.tgz
 


### PR DESCRIPTION
- Updated Dockerfile and Added ingOR.sh, ingbld_install.sh for Ingres Net ingbuild based installation
- Updated Dockerfile for latest and GA OpenROAD patch file name
- Now copied openroadg.war instead of openroadg.jar
- Removed .bash extension from orspogsvrstart and orspogsvrstop as per the latest patch change
- Updated README accordingly